### PR TITLE
Allow modification of PsychometricTest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # PsychometricTests.jl
 
-[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://p-gw.github.io/PsychometricTests.jl/stable/)
-[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://p-gw.github.io/PsychometricTests.jl/dev/)
-[![Build Status](https://github.com/p-gw/PsychometricTests.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/p-gw/PsychometricTests.jl/actions/workflows/CI.yml?query=branch%3Amain)
-[![Coverage](https://codecov.io/gh/p-gw/PsychometricTests.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/p-gw/PsychometricTests.jl)
+[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaPsychometrics.github.io/PsychometricTests.jl/stable/)
+[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaPsychometrics.github.io/PsychometricTests.jl/dev/)
+[![Build Status](https://github.com/JuliaPsychometrics/PsychometricTests.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/JuliaPsychometrics/PsychometricTests.jl/actions/workflows/CI.yml?query=branch%3Amain)
+[![Coverage](https://codecov.io/gh/JuliaPsychometrics/PsychometricTests.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/JuliaPsychometrics/PsychometricTests.jl)
 
 PsychometricTests.jl provides efficient data structures for psychometric testing in Julia.
 It serves as an entry point to the [JuliaPsychometrics](https://github.com/JuliaPsychometrics)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -11,11 +11,11 @@ DocMeta.setdocmeta!(
 makedocs(;
     modules = [PsychometricTests],
     authors = "Philipp Gewessler",
-    repo = "https://github.com/p-gw/PsychometricTests.jl/blob/{commit}{path}#{line}",
+    repo = "https://github.com/JuliaPsychometrics/PsychometricTests.jl/blob/{commit}{path}#{line}",
     sitename = "PsychometricTests.jl",
     format = Documenter.HTML(;
         prettyurls = get(ENV, "CI", "false") == "true",
-        canonical = "https://p-gw.github.io/PsychometricTests.jl",
+        canonical = "https://JuliaPsychometrics.github.io/PsychometricTests.jl",
         edit_link = "main",
         assets = String[],
     ),
@@ -26,4 +26,7 @@ makedocs(;
     ],
 )
 
-deploydocs(; repo = "github.com/p-gw/PsychometricTests.jl", devbranch = "main")
+deploydocs(;
+    repo = "github.com/JuliaPsychometrics/PsychometricTests.jl",
+    devbranch = "main",
+)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,9 +1,9 @@
 # PsychometricTests.jl
 
-[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://p-gw.github.io/PsychometricTests.jl/stable/)
-[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://p-gw.github.io/PsychometricTests.jl/dev/)
-[![Build Status](https://github.com/p-gw/PsychometricTests.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/p-gw/PsychometricTests.jl/actions/workflows/CI.yml?query=branch%3Amain)
-[![Coverage](https://codecov.io/gh/p-gw/PsychometricTests.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/p-gw/PsychometricTests.jl)
+[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaPsychometrics.github.io/PsychometricTests.jl/stable/)
+[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaPsychometrics.github.io/PsychometricTests.jl/dev/)
+[![Build Status](https://github.com/JuliaPsychometrics/PsychometricTests.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/JuliaPsychometrics/PsychometricTests.jl/actions/workflows/CI.yml?query=branch%3Amain)
+[![Coverage](https://codecov.io/gh/JuliaPsychometrics/PsychometricTests.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/JuliaPsychometrics/PsychometricTests.jl)
 
 PsychometricTests.jl provides data structures for psychometric testing in Julia.
 It serves as an entry point to the [JuliaPsychometrics](https://github.com/JuliaPsychometrics)

--- a/src/PsychometricTests.jl
+++ b/src/PsychometricTests.jl
@@ -10,6 +10,7 @@ export getitems, getpersons, getresponses
 export eachitem, eachperson, eachresponse
 export nitems, npersons, nresponses
 export additems!, addpersons!, addresponses!
+export invalidate!
 
 export Response, BasicResponse, getvalue, getitemid, getpersonid
 export Person, BasicPerson

--- a/src/PsychometricTests.jl
+++ b/src/PsychometricTests.jl
@@ -9,6 +9,7 @@ export PsychometricTest
 export getitems, getpersons, getresponses
 export eachitem, eachperson, eachresponse
 export nitems, npersons, nresponses
+export additems!, addpersons!, addresponses!
 
 export Response, BasicResponse, getvalue, getitemid, getpersonid
 export Person, BasicPerson

--- a/test/test.jl
+++ b/test/test.jl
@@ -58,25 +58,68 @@
     end
 
     @testset "Setters" begin
-        t2 = PsychometricTest(data)
-        @test additems!(t2, BasicItem(3)) == [BasicItem(i) for i in 1:3]
-        @test nitems(t2) == 3
-        @test_throws ArgumentError additems!(t2, BasicItem(3))
+        t = PsychometricTest(data)
 
-        @test additems!(t2, [BasicItem(i) for i in 4:5]) == [BasicItem(i) for i in 1:5]
-        @test nitems(t2) == 5
-        @test_throws ArgumentError additems!(t2, [BasicItem(4)])
+        # additems!
+        @test additems!(t, BasicItem(3)) == [BasicItem(i) for i in 1:3]
+        @test nitems(t) == 3
+        @test_throws ArgumentError additems!(t, BasicItem(3))
 
-        @test addpersons!(t2, BasicPerson(4)) == [BasicPerson(p) for p in 1:4]
-        @test npersons(t2) == 4
-        @test_throws ArgumentError addpersons!(t2, BasicPerson(1))
+        @test additems!(t, [BasicItem(i) for i in 4:5]) == [BasicItem(i) for i in 1:5]
+        @test nitems(t) == 5
+        @test_throws ArgumentError additems!(t, [BasicItem(4)])
 
-        @test addpersons!(t2, [BasicPerson(p) for p in 5:6]) == [BasicPerson(p) for p in 1:6]
-        @test npersons(t2) == 6
-        @test_throws ArgumentError addpersons!(t2, [BasicPerson(1)])
+        # addpersons!
+        @test addpersons!(t, BasicPerson(4)) == [BasicPerson(p) for p in 1:4]
+        @test npersons(t) == 4
+        @test_throws ArgumentError addpersons!(t, BasicPerson(1))
+
+        @test addpersons!(t, [BasicPerson(p) for p in 5:6]) == [BasicPerson(p) for p in 1:6]
+        @test npersons(t) == 6
+        @test_throws ArgumentError addpersons!(t, [BasicPerson(1)])
+
+        # addresponses!
+        t = PsychometricTest(data)
+        @test_throws ArgumentError addresponses!(t, BasicResponse(10, 1, 1))
+        @test_throws ArgumentError addresponses!(t, BasicResponse(1, 10, 1))
+        @test_throws ArgumentError addresponses!(t, BasicResponse(1, 1, 1))
+
+        oldt = deepcopy(t)
+        addpersons!(t, BasicPerson(4))
+
+        new_responses = [BasicResponse(i, 4, 1) for i in 1:2]
+        @test addresponses!(t, new_responses) == vcat(getresponses(oldt), new_responses)
+        @test oldt.person_ptr != t.person_ptr
+        @test oldt.item_ptr != t.item_ptr
+        @test t[4, :] == new_responses
+
+        for p in 1:3
+            @test t[p, :] == oldt[p, :]
+        end
+
+        for i in 1:2
+            @test t[1:3, [i]] == oldt[1:3, [i]]
+        end
+
+        # manual invalidation
+        t2 = deepcopy(oldt)
+        addpersons!(t2, BasicPerson(4))
+        addresponses!(t2, new_responses, invalidate = false)
+        @test oldt.person_ptr == t2.person_ptr
+        @test oldt.item_ptr == t2.item_ptr
+
+        invalidate!(t2)
+        @test t2.person_ptr == t.person_ptr
+        @test t2.item_ptr == t2.item_ptr
     end
 
     @testset "Matrix" begin
+        t = PsychometricTest(data)
         @test Matrix(t) == data
+        @test eltype(Matrix(t)) == Int
+
+        addpersons!(t, BasicPerson(4))
+        addresponses!(t, BasicResponse(1, 4, 1))
+        @test eltype(Matrix(t)) == Union{Missing,Int}
     end
 end

--- a/test/test.jl
+++ b/test/test.jl
@@ -111,6 +111,16 @@
         invalidate!(t2)
         @test t2.person_ptr == t.person_ptr
         @test t2.item_ptr == t2.item_ptr
+
+        # overwrite responses
+        t = PsychometricTest(data)
+        addresponses!(t, BasicResponse(1, 1, 1), force = true)
+        @test length(getresponses(t)) == length(data)
+
+        # make sure ordering is preserved
+        @test t[1, :] == [BasicResponse(1, 1, 1), BasicResponse(2, 1, 1)]
+        @test t[:, 1] ==
+              [BasicResponse(1, 1, 1), BasicResponse(1, 2, 1), BasicResponse(1, 3, 1)]
     end
 
     @testset "Matrix" begin

--- a/test/test.jl
+++ b/test/test.jl
@@ -57,6 +57,25 @@
         @test nresponses(t) == 6
     end
 
+    @testset "Setters" begin
+        t2 = PsychometricTest(data)
+        @test additems!(t2, BasicItem(3)) == [BasicItem(i) for i in 1:3]
+        @test nitems(t2) == 3
+        @test_throws ArgumentError additems!(t2, BasicItem(3))
+
+        @test additems!(t2, [BasicItem(i) for i in 4:5]) == [BasicItem(i) for i in 1:5]
+        @test nitems(t2) == 5
+        @test_throws ArgumentError additems!(t2, [BasicItem(4)])
+
+        @test addpersons!(t2, BasicPerson(4)) == [BasicPerson(p) for p in 1:4]
+        @test npersons(t2) == 4
+        @test_throws ArgumentError addpersons!(t2, BasicPerson(1))
+
+        @test addpersons!(t2, [BasicPerson(p) for p in 5:6]) == [BasicPerson(p) for p in 1:6]
+        @test npersons(t2) == 6
+        @test_throws ArgumentError addpersons!(t2, [BasicPerson(1)])
+    end
+
     @testset "Matrix" begin
         @test Matrix(t) == data
     end


### PR DESCRIPTION
This pull request implements setter functions for items, persons, and responses. 

Concretely, 

- `additems!`: Add item(s) to the `items` field of a `PsychometricTest`
- `addpersons!`: Add person(s) to the `persons` field of a `PsychometricTest`
- `addresponses!`: Add response(s) to the `responses` field of a `PsychometricTest`

All functions implement validation of the resulting test. For `additems!` and `addpersons!` it is checked, that the `id` fields are still unique. For `addresponses!` it is checked if

1. The item id exists in the `items` field of a test
2. The person id exists in the `persons` field of a test
3. The id combination already exists as a response.