### PR TITLE
Performance optimization for simple tests

### DIFF
--- a/src/response.jl
+++ b/src/response.jl
@@ -13,6 +13,7 @@ abstract type Response end
 
 Get the response value of `response`.
 """
+getvalue(response) = response
 getvalue(response::Response) = response.value
 
 """

--- a/test/psychometric_test.jl
+++ b/test/psychometric_test.jl
@@ -7,7 +7,7 @@
         @test length(t.items) == 3
         @test length(t.persons) == 10
         @test size(t.responses) == (10, 3)
-        @test eltype(t.responses) == BasicResponse{Int}
+        @test eltype(t.responses) == Int
         @test t.scales == Dict{Symbol,Any}()
 
         scales = Dict(:s1 => 1:2, :s2 => 3)
@@ -21,7 +21,7 @@
         @test length(t.items) == 3
         @test length(t.persons) == 10
         @test size(t.responses) == (10, 3)
-        @test eltype(t.responses) == BasicResponse{Int}
+        @test eltype(t.responses) == Int
         @test t.scales == Dict{Symbol,Any}()
 
         t = PsychometricTest(data; scales)


### PR DESCRIPTION
This pull request implements a performance optimization for tests where responses only contain a single value. 

For these tests, `responses` are no longer wrapped in `BasicResponse`. 
This avoids allocations for reconstructing the response matrix via `response_matrix`, thus avoiding overhead in performance in comparison to `Matrix`. 